### PR TITLE
Execute non-delayed macros immediately to preserve relative ordering

### DIFF
--- a/common/src/main/java/dev/terminalmc/commandkeys/config/Macro.java
+++ b/common/src/main/java/dev/terminalmc/commandkeys/config/Macro.java
@@ -474,7 +474,11 @@ public class Macro {
      * Schedules the message to send after {@code delay} ticks.
      */
     private void schedule(int delay, String message, boolean addToHistory, boolean showHudMessage) {
-        scheduledMessages.add(new ScheduledMessage(delay, message, addToHistory, showHudMessage));
+        if (delay > 0) {
+            scheduledMessages.add(new ScheduledMessage(delay, message, addToHistory, showHudMessage));
+        } else {
+            CommandKeys.send(message, showHudMessage, addToHistory);
+        }
     }
 
     private void scheduleAll(boolean standardDelay) {


### PR DESCRIPTION
Due to SEND macros being "delayed" by at least 0 ticks with the same not being the case for TYPE macros, SEND macros are always executed first if they are bound to the same key (irrespective of their ordering in the macro list). This can prevent some TYPE macros from taking effect.